### PR TITLE
Mermaid, reenable self edges

### DIFF
--- a/src/rt/mermaid.h
+++ b/src/rt/mermaid.h
@@ -38,12 +38,7 @@ void mermaid(std::vector<Edge> &roots, std::ostream &out) {
       out << "  id" << visited[src] << " -->|" << key << "| ";
     }
     if (visited.find(dst) != visited.end()) {
-      if (visited[dst] == visited[src])
-        /// Currently required due to 
-        ///  https://github.com/mermaid-js/mermaid/issues/5820
-        out << "HasSelfEdge" << std::endl;
-      else
-        out << "id" << visited[dst] << std::endl;
+      out << "id" << visited[dst] << std::endl;
       return false;
     }
     auto curr_id = id++;


### PR DESCRIPTION
Basically a revert of d57d51f.

https://github.com/mermaid-js/mermaid/issues/5820 is still open, but they've added a workaround, that is already available in VSCode. 

![image](https://github.com/user-attachments/assets/d16553c6-74ef-4dd1-982b-67b935606193)
