### PR TITLE
Add string values and allow nested lookups

### DIFF
--- a/src/lang/bytecode.h
+++ b/src/lang/bytecode.h
@@ -5,8 +5,11 @@
 inline const trieste::TokenDef LoadFrame{"load_frame", trieste::flag::print};
 inline const trieste::TokenDef StoreFrame{"store_frame", trieste::flag::print};
 inline const trieste::TokenDef LoadField{"load_field", trieste::flag::print};
-inline const trieste::TokenDef StoreField{"store_field", trieste::flag::print};
+inline const trieste::TokenDef StoreField{"store_field"};
 inline const trieste::TokenDef CreateObject{"create_object"};
+inline const trieste::TokenDef Dictionary{"dictionary"};
+inline const trieste::TokenDef String{"string", trieste::flag::print};
+
 inline const trieste::TokenDef CreateRegion{"create_region"};
 inline const trieste::TokenDef FreezeObject{"freeze_object"};
 inline const trieste::TokenDef Null{"null"};

--- a/src/rt/rt.cc
+++ b/src/rt/rt.cc
@@ -8,7 +8,12 @@
 
 namespace objects {
 
-DynObject *make_object(std::string name) { return new DynObject(name); }
+DynObject *make_object(std::string value, std::string name) {
+  auto obj = new DynObject(name, new value::StrValue(value));
+  assert(obj->get_value());
+  return obj;
+}
+DynObject *make_object(std::string name) { return new DynObject(name, nullptr); }
 
 DynObject *get_frame() { return DynObject::frame(); }
 
@@ -16,10 +21,20 @@ void freeze(DynObject *obj) { obj->freeze(); }
 
 void create_region(DynObject *object) { object->create_region(); }
 
-DynObject *get(DynObject *obj, std::string key) { return obj->get(key); }
+DynObject *get(DynObject *obj, std::string key) {
+  return obj->get(key);
+}
+DynObject *get(DynObject *obj, DynObject *key) {
+  auto value = key->get_value();
+  assert(value);
+  return get(obj, *value->expect_str_value());
+}
 
 DynObject *set(DynObject *obj, std::string key, DynObject *value) {
   return obj->set(key, value);
+}
+DynObject *set(DynObject *obj, DynObject *key, DynObject *value) {
+  return set(obj, *key->get_value()->expect_str_value(), value);
 }
 
 void add_reference(DynObject *src, DynObject *target) {

--- a/src/rt/rt.h
+++ b/src/rt/rt.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cassert>
 
 namespace objects {
 class DynObject;
@@ -12,6 +13,7 @@ struct Edge {
   DynObject *target;
 };
 
+DynObject *make_object(std::string str_value, std::string name);
 DynObject *make_object(std::string name = "");
 DynObject *get_frame();
 void clear_frame();
@@ -20,7 +22,9 @@ void freeze(DynObject *obj);
 void create_region(DynObject *objects);
 
 DynObject *get(DynObject *src, std::string key);
+DynObject *get(DynObject *src, DynObject *key);
 DynObject *set(DynObject *dst, std::string key, DynObject *value);
+DynObject *set(DynObject *dst, DynObject *key, DynObject *value);
 
 void add_reference(DynObject *src, DynObject *target);
 void remove_reference(DynObject *src, DynObject *target);

--- a/tests/str_val.vpy
+++ b/tests/str_val.vpy
@@ -1,0 +1,16 @@
+a = {}
+a["b"] = {}
+a["b"]["c"] = "not None"
+a.self = a
+
+k = "c"
+l = {}
+l.key = k
+
+if a.b[l.key] == None:
+    pass = {}
+    drop pass
+
+drop l
+drop k
+drop a


### PR DESCRIPTION
This PR has two major changes:
* It adds a `Value` field to `DynObject` which can be used for "primitive" data like integers and strings
* Lookups now use a value from the stack as the key.

The new test file shows how these features can be used together:

```py
a = {}
a["b"] = {}
a["b"]["c"] = "not None"
a.self = a

k = "c"
l = {}
l.key = k

if a.b[l.key] == None:
    pass = {}
    drop pass

drop l
drop k
drop a
```

---

Regarding the implementation: I considered how to best add values to `DynObject`s. I considered adding the `str_value` method directly to the class as a virtual method. However, I believe that would turn the `DynObject` into a super class that does too many things.

The current implementation basically sees the `DynObject` as the smart pointer that keeps track of the RC, region, and pointers to other objects. All the good memory management stuff. While the stored value is used for expressions.

Dictionaries are a weird split. They are theoretically a value, but Python objects like integers and Strings still behave like a dictionary, in the way that they have methods and fields with additional information. Since they also manage pointers, I've decided to keep the current implementation.

This PR only adds string literals as value type. Adding functions and integers should be super simple with the setup, but that is better left as a followup when they're needed.

---

Please reach out if you have any questions. I'm also happy to call and discuss the changes.