### PR TITLE
Makefile: Remove commands that mention miniml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,6 @@ build/miniml: build
 build:
 	mkdir -p build; cd build; cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Debug
 
-buildf: 
-	mkdir -p out; touch out/$f.trieste; ./build/miniml build ./programs/$f.miniml -o ./out/$f.trieste 
-	
-buildp: 
-	touch out/$f.trieste; ./build/miniml build programs/$f.miniml -o out/$f.trieste -p $p  
-
 test:
 	cd build; ctest
 


### PR DESCRIPTION
I forgot to remove the miniml specific make commands. 