### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# Verona Dynamic Language experiment
+# FrankenScript Dynamic Language experiment
 
+This repository contains a toy programming language called "FrankenScript" with Python-like syntax and Python/JavaScript-inspired semantics.
+The purpose of FrankenScript is to explore the design space for adding a region-based ownership system inspired by [Reggio](https://doi.org/10.1145/3622846) and a concurrency
+model inspired by [behaviour-oriented concurrency](https://doi.org/10.1145/3622852) to dynamic programming languages to unlock parallelism in a way that is free from data-races
+(and also deadlocks, if the full behaviour-oriented concurrency model is adopted). FrankenScript is implemented using [Trieste](https://doi.org/10.1145/3687997.3695647).
+To this end, FrankenScript programs generate a file called `mermaid.md` with a Mermaid diagram per line in the source program showing the object and region
+graph of the program at that program point. 
 
 ## Pre-requisites
 
@@ -31,15 +37,15 @@ ctest
 The project can be run by
 
 ```bash
-./build/verona_dyn build foo.vpy
+./build/frank build foo.fs
 ```
 
-where `foo.vpy` is a Verona dynamic language program. This generates a file `mermaid.md` that contains the Mermaid representation of the heap after each step of the program.
+where `foo.fs` is a FrankenScript program. This generates a file `mermaid.md` that contains the Mermaid representation of the heap after each step of the program.
 
 You can run in interactive mode by running:
 
 ```bash
-./build/verona_dyn build --interactive foo.vpy
+./build/frank build --interactive foo.fs
 ```
 
 Which will keep overwritting the `mermaid.md` file with the new heap state after each step.


### PR DESCRIPTION
Reflected the name change in the README. Also added links to Reggio, BoC, and Trieste.

*NOTE*: assumes we want to change the file extension to `.fs` and `verona_dyn` to `frank`. 