### PR TITLE
Disable implicit freezing by default

### DIFF
--- a/docs/builtin.md
+++ b/docs/builtin.md
@@ -61,9 +61,9 @@ Dissolves the given region into the local region. The bridge object will lose th
 
 ## Pragmas
 
-#### `pragma_disable_implicit_freezing()`
+#### `pragma_enable_implicit_freezing()`
 
-Disables implicit freezing for the rest of the program.
+Enables implicit freezing for the rest of the program.
 
 #### `pragma_mermaid_draw_regions_nested(bool)`
 

--- a/src/rt/core/builtin.cc
+++ b/src/rt/core/builtin.cc
@@ -338,12 +338,12 @@ namespace rt::core
 
   void pragma_builtins()
   {
-    add_builtin("pragma_disable_implicit_freezing", [](auto, auto args) {
+    add_builtin("pragma_enable_implicit_freezing", [](auto, auto args) {
       if (args != 0)
       {
-        ui::error("pragma_disable_implicit_freezing() expected 0 arguments");
+        ui::error("pragma_enable_implicit_freezing() expected 0 arguments");
       }
-      objects::Region::pragma_implicit_freezing = false;
+      objects::Region::pragma_implicit_freezing = true;
       return std::nullopt;
     });
 

--- a/src/rt/objects/prototype_object.h
+++ b/src/rt/objects/prototype_object.h
@@ -12,7 +12,7 @@ namespace rt::objects
     PrototypeObject(
       std::string name_,
       objects::DynObject* prototype = nullptr,
-      objects::Region* region = objects::get_local_region())
+      objects::Region* region = objects::immutable_region)
     : objects::DynObject(prototype, region), name(name_)
     {}
 

--- a/src/rt/objects/region.h
+++ b/src/rt/objects/region.h
@@ -32,7 +32,7 @@ namespace rt::objects
     static inline thread_local std::set<Region*> dirty_regions{};
 
     /// Indicates if implicit freezing is enabled
-    static inline bool pragma_implicit_freezing = true;
+    static inline bool pragma_implicit_freezing = false;
 
     // The local reference count is the number of references to objects in the
     // region from local region. Using non-zero LRC for subregions ensures we

--- a/tests/cowns/cown_from_immutable.frank
+++ b/tests/cowns/cown_from_immutable.frank
@@ -1,14 +1,8 @@
-# Create two regions
-r1 = Region()
-r2 = Region()
-
-# Create unfrozen data to share
+# Create a value to share
 share = {}
-share.text = "Shared Info"
-r1.info = share
 
-# Trigger implicit freeze by referencing it from r2
-r2.info = share
+# Freeze the value to make sure it can be put in a cown
+freeze(share)
 
 # Should succeed, as 'share' is now immutable
-c = Cown(move share)
+c = Cown(share)

--- a/tests/regions/fail_cross_region_ref.frank
+++ b/tests/regions/fail_cross_region_ref.frank
@@ -1,5 +1,3 @@
-pragma_disable_implicit_freezing()
-
 # Root a
 a = Region()
 

--- a/tests/regions/implicit_freeze_1.frank
+++ b/tests/regions/implicit_freeze_1.frank
@@ -1,3 +1,5 @@
+pragma_enable_implicit_freezing()
+
 # Create two regions
 r1 = Region()
 r2 = Region()

--- a/tests/regions/implicit_freeze_2.frank
+++ b/tests/regions/implicit_freeze_2.frank
@@ -1,3 +1,5 @@
+pragma_enable_implicit_freezing()
+
 # Create two regions
 r1 = Region()
 r2 = Region()

--- a/tests/regions/merge_bad_3.frank
+++ b/tests/regions/merge_bad_3.frank
@@ -1,4 +1,3 @@
-pragma_disable_implicit_freezing()
 r1 = Region()
 r2 = Region()
 r1.r2 = r2

--- a/tests/regions/region_bad_1.frank
+++ b/tests/regions/region_bad_1.frank
@@ -1,5 +1,3 @@
-pragma_disable_implicit_freezing()
-
 # Fails: can't add anything but the bridge object to a region
 r = Region()
 a = {}

--- a/tests/regions/region_bad_2.frank
+++ b/tests/regions/region_bad_2.frank
@@ -1,5 +1,3 @@
-pragma_disable_implicit_freezing()
-
 # Fails: can't add anything but the bridge object to a region
 r = Region()
 r2 = Region()

--- a/tests/regions/region_close_fail_1.frank
+++ b/tests/regions/region_close_fail_1.frank
@@ -1,11 +1,14 @@
 # Construct regions
 r1 = Region()
 
-# Create a local string to share the `String` prototype
-local_string = "Hello Local"
+# Create a prototype
+local_ty = {}
 
-# This also moves the `String` prototype
-r1.something = "Important string"
+# Create a local object to share the `local_ty` prototype
+local_value = create(local_ty)
+
+# Create a value in the region, this also moves the `local_ty` prototype
+r1.region_value = create(local_ty)
 
 # This should fail, since implicit freezing is disabled
 close(r1)


### PR DESCRIPTION
TODOs:
1. [x] Discuss if it's fine to make built-in prototypes immutable by default
2. [ ] Update figure 9, since `[Frame]` is now frozen
    * https://github.com/fxpl/pyrona/pull/15
4. [ ] Update the paper text about `pragma_disable_implicit_freezing()`
    * https://github.com/fxpl/pyrona/pull/15

cc: @TobiasWrigstad 